### PR TITLE
Allow custom simulation options

### DIFF
--- a/plugins/spectre/src/lib.rs
+++ b/plugins/spectre/src/lib.rs
@@ -406,6 +406,7 @@ fn get_analyses(input: &[Analysis]) -> Result<Vec<String>> {
 }
 
 fn analysis_line(input: &Analysis, prefix: &str, num: usize) -> Result<String> {
+    use std::fmt::Write;
     let name = analysis_name(prefix, num);
     Ok(match input {
         Analysis::Op(_) => format!("{name} dc"),
@@ -415,21 +416,37 @@ fn analysis_line(input: &Analysis, prefix: &str, num: usize) -> Result<String> {
             } else {
                 String::new()
             };
-            format!(
+            let mut line = format!(
                 "{name} tran step={} stop={} start={}{}",
                 a.step, a.stop, a.start, strobe
-            )
+            );
+            for (k, v) in a.opts.iter() {
+                write!(&mut line, " {}={}", k, v).unwrap();
+            }
+            line
         }
-        Analysis::Ac(a) => format!(
-            "{name} ac start={} stop={} {}",
-            a.fstart,
-            a.fstop,
-            fmt_sweep_mode(a.sweep, a.points),
-        ),
-        Analysis::Dc(a) => format!(
-            "{name} dc {} start={} stop={} step={}",
-            a.sweep, a.start, a.stop, a.step
-        ),
+        Analysis::Ac(a) => {
+            let mut line = format!(
+                "{name} ac start={} stop={} {}",
+                a.fstart,
+                a.fstop,
+                fmt_sweep_mode(a.sweep, a.points),
+            );
+            for (k, v) in a.opts.iter() {
+                write!(&mut line, " {}={}", k, v).unwrap();
+            }
+            line
+        }
+        Analysis::Dc(a) => {
+            let mut line = format!(
+                "{name} dc {} start={} stop={} step={}",
+                a.sweep, a.start, a.stop, a.step
+            );
+            for (k, v) in a.opts.iter() {
+                write!(&mut line, " {}={}", k, v).unwrap();
+            }
+            line
+        }
         Analysis::MonteCarlo(a) => {
             let mut monte_carlo = format!("{name} montecarlo");
             monte_carlo.push_str(&format!(

--- a/substrate/src/verification/simulation/mod.rs
+++ b/substrate/src/verification/simulation/mod.rs
@@ -155,6 +155,9 @@ pub struct DcAnalysis {
     pub start: f64,
     pub stop: f64,
     pub step: f64,
+    /// Simulator-specific options.
+    #[builder(default)]
+    pub opts: HashMap<String, String>,
 }
 
 impl DcAnalysis {
@@ -172,6 +175,9 @@ pub struct TranAnalysis {
     pub start: f64,
     #[builder(default, setter(strip_option))]
     pub strobe_period: Option<f64>,
+    /// Simulator-specific options.
+    #[builder(default)]
+    pub opts: HashMap<String, String>,
 }
 
 impl TranAnalysis {
@@ -187,6 +193,9 @@ pub struct AcAnalysis {
     pub fstop: f64,
     pub points: usize,
     pub sweep: SweepMode,
+    /// Simulator-specific options.
+    #[builder(default)]
+    pub opts: HashMap<String, String>,
 }
 
 impl AcAnalysis {


### PR DESCRIPTION
Adds String key/value pairs to simulation analyses.
Interpreting these values is up to the simulator plugin.
